### PR TITLE
Remove unused iv from Fernet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ import 'dart:convert';
 void main() {
   final plainText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
   final key = Key.fromUtf8('my32lengthsupersecretnooneknows1');
-  final iv = IV.fromLength(16);
 
   final b64key = Key.fromUtf8(base64Url.encode(key.bytes));
   // if you need to use the ttl feature, you'll need to use APIs in the algorithm itself


### PR DESCRIPTION
remove iv variable from Fernet example, it is not used for Fernet and it being there was just confusing.